### PR TITLE
Remove redundant newline in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,6 @@ func main() {
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
-	fmt.Println("Serving on " + srvAddr + "....\n")
+	fmt.Println("Serving on " + srvAddr)
 	log.Fatal(srv.ListenAndServe())
 }


### PR DESCRIPTION
[nightly test](https://tekton-releases.appspot.com/build/tekton-prow/logs/periodic-tekton-catalog-integration-tests/1507192148427018240/) of codecov task in tektoncd/catalog is failing with the reason
```
2022/03/25 03:22:03 Decoded script /tekton/scripts/script-0-rwvkq
# github.com/chmouel/go-rest-api-test
./main.go:25:2: fmt.Println arg list ends with redundant newline
ok  	github.com/chmouel/go-rest-api-test/pkg/reflector	0.032s	coverage: 88.6% of statements
```
Removing the redundant new line fixes the tests
